### PR TITLE
Fixed providing a custom theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import React from "react"
 import { render } from "react-dom"
 import { ThemeProvider } from "d10m"
 
-import "./theme"
+import theme from "./theme"
 
 const App = () => <h1>hello world</h1>
 

--- a/src/theme/ThemeProvider.js
+++ b/src/theme/ThemeProvider.js
@@ -6,10 +6,13 @@ import './global'
 import theme from './defaultTheme'
 
 const ThemeProvider = props => (
-  <StyledThemeProvider theme={theme}>{props.children}</StyledThemeProvider>
+  <StyledThemeProvider theme={props.theme || theme}>
+    {props.children}
+  </StyledThemeProvider>
 )
 
 ThemeProvider.propTypes = {
+  theme: PropTypes.object,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.func


### PR DESCRIPTION
Hi!

I have started using d10m on a personal project, although it seems that it's impossible to add a custom theme as the d10m `ThemeProvider` is not using the prop, so you would always end up with the custom theme.

There is a workaround which is to use the `ThemeProvider` from `styled-components` but then you wouldn't get the global reset.

This PR should fix it.